### PR TITLE
Enables the package to return the quill instance to a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ Simply use the action and listen to events using the `text-change` event. The ev
 <div class="editor" use:quill={options} on:text-change={e => content =
 e.detail}/>
 ```
+Or to retrieve the quill instance to make direct API calls:
+```html
+<script>
+  import { quill } from "svelte-quill";
+
+  const options = { ... }
+  var quillInstance;
+  onMount(()=>{
+		const editorDiv = document.getElementById("editor")
+		quillInstance = quill(editorDiv, options)
+		quillInstance.setText("Hello World")
+	})
+</script>
+
+<div id="editor"/>
+```
+
 
 ## Options
 

--- a/dist/index.cjs.js
+++ b/dist/index.cjs.js
@@ -7,7 +7,7 @@ function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'defau
 var Quill = _interopDefault(require('quill'));
 
 function quill(node, options) {
-  const quill = new Quill(node, {
+  const quillInstance = new Quill(node, {
     modules: {
       toolbar: [
         [{ header: [1, 2, 3, false] }],
@@ -21,16 +21,17 @@ function quill(node, options) {
   });
   const container = node.getElementsByClassName("ql-editor")[0];
 
-  quill.on("text-change", function(delta, oldDelta, source) {
+  quillInstance.on("text-change", function(delta, oldDelta, source) {
     node.dispatchEvent(
       new CustomEvent("text-change", {
         detail: {
           html: container.innerHTML,
-          text: quill.getText()
+          text: quillInstance.getText()
         }
       })
     );
   });
+  return quillInstance;
 }
 
 exports.quill = quill;

--- a/dist/index.esm.js
+++ b/dist/index.esm.js
@@ -1,7 +1,7 @@
 import Quill from 'quill';
 
 function quill(node, options) {
-  const quill = new Quill(node, {
+  const quillInstance = new Quill(node, {
     modules: {
       toolbar: [
         [{ header: [1, 2, 3, false] }],
@@ -15,16 +15,17 @@ function quill(node, options) {
   });
   const container = node.getElementsByClassName("ql-editor")[0];
 
-  quill.on("text-change", function(delta, oldDelta, source) {
+  quillInstance.on("text-change", function(delta, oldDelta, source) {
     node.dispatchEvent(
       new CustomEvent("text-change", {
         detail: {
           html: container.innerHTML,
-          text: quill.getText()
+          text: quillInstance.getText()
         }
       })
     );
   });
+  return quillInstance;
 }
 
 export { quill };

--- a/dist/index.umd.js
+++ b/dist/index.umd.js
@@ -11421,31 +11421,32 @@
 	var Quill = unwrapExports(quill);
 
 	function quill$1(node, options) {
-	  const quill = new Quill(node, {
-	    modules: {
-	      toolbar: [
-	        [{ header: [1, 2, 3, false] }],
-	        ["bold", "italic", "underline", "strike"],
-	        ["link", "code-block"]
-	      ]
-	    },
-	    placeholder: "Type something...",
-	    theme: "snow", // or 'bubble'
-	    ...options
-	  });
-	  const container = node.getElementsByClassName("ql-editor")[0];
-
-	  quill.on("text-change", function(delta, oldDelta, source) {
-	    node.dispatchEvent(
-	      new CustomEvent("text-change", {
-	        detail: {
-	          html: container.innerHTML,
-	          text: quill.getText()
-	        }
-	      })
-	    );
-	  });
-	}
+		const quillInstance = new Quill(node, {
+		  modules: {
+			toolbar: [
+			  [{ header: [1, 2, 3, false] }],
+			  ["bold", "italic", "underline", "strike"],
+			  ["link", "code-block"]
+			]
+		  },
+		  placeholder: "Type something...",
+		  theme: "snow", // or 'bubble'
+		  ...options
+		});
+		const container = node.getElementsByClassName("ql-editor")[0];
+  
+		quillInstance.on("text-change", function(delta, oldDelta, source) {
+		  node.dispatchEvent(
+			new CustomEvent("text-change", {
+			  detail: {
+				html: container.innerHTML,
+				text: quillInstance.getText()
+			  }
+			})
+		  );
+		});
+		return quillInstance;
+	  }
 
 	exports.quill = quill$1;
 


### PR DESCRIPTION
This PR enables the package to return the quill instance to a variable. This is useful when you have more than one editor on a page, or need to access the native Quill API calls on an instance directly.